### PR TITLE
Fix typo (arduino)

### DIFF
--- a/.db/forums.json
+++ b/.db/forums.json
@@ -71,7 +71,7 @@
         },
 
         {
-            "name" : "ardunio",
+            "name" : "arduino",
             "url" : "https://create.arduino.cc/projecthub/{}",
             "check_code" : "2",
             "check" : 404


### PR DESCRIPTION
There is typo in the name of https://www.arduino.cc/. 

"ardunio" -> "arduino"
