### PR TITLE
Update arduino and weheartit

### DIFF
--- a/.db/forums.json
+++ b/.db/forums.json
@@ -72,9 +72,9 @@
 
         {
             "name" : "arduino",
-            "url" : "https://projecthub.arduino.cc/{username}",
-            "check_code" : "2",
-            "check" : 404
+            "url" : "https://projecthub.arduino.cc/{}",
+            "check_code" : "3",
+            "check" : "Oh no! Nothing to discover here."
         },
 
         {

--- a/.db/socmint.json
+++ b/.db/socmint.json
@@ -2084,7 +2084,7 @@
     "156" : {
         "name" : "weheartit",
         "desc" : "",
-        "type" : "notapi",
+        "type" : "ignored",
         "url"  : "https://weheartit.com/{}",
         "messages" : {
             "notfound" : "Oops! You've landed on a moving target!"


### PR DESCRIPTION
fix #9 

- Arduino: `projecthub.arduino.cc` returns page saying "Oh no! Nothing to discover here." for invalid usernames.
- WeHeartIt: Temporarily disabled by changing type (since Slash currently only processes the website with "notapi" type)